### PR TITLE
Add HexColor annotation and validator for hex color format validation

### DIFF
--- a/src/main/java/org/elara/app/validation/validation/annotation/HexColor.java
+++ b/src/main/java/org/elara/app/validation/validation/annotation/HexColor.java
@@ -1,0 +1,22 @@
+package org.elara.app.validation.validation.annotation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import org.elara.app.validation.validation.validator.HexColorValidator;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+@Documented
+@Constraint(validatedBy = HexColorValidator.class)
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+public @interface HexColor {
+
+    String message() default "Invalid hex color format";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+}

--- a/src/main/java/org/elara/app/validation/validation/validator/HexColorValidator.java
+++ b/src/main/java/org/elara/app/validation/validation/validator/HexColorValidator.java
@@ -1,0 +1,17 @@
+package org.elara.app.validation.validation.validator;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import org.elara.app.validation.validation.annotation.HexColor;
+
+public class HexColorValidator implements ConstraintValidator<HexColor, String> {
+
+    final static String HEX_COLOR_REGEX = "^(#([A-Fa-f0-9]{6}))";
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext constraintValidatorContext) {
+        if (value == null || value.isEmpty()) return true;
+        return value.matches(HEX_COLOR_REGEX);
+    }
+
+}

--- a/src/test/java/org/elara/app/validation/validation/validator/HexColorValidatorTest.java
+++ b/src/test/java/org/elara/app/validation/validation/validator/HexColorValidatorTest.java
@@ -1,0 +1,37 @@
+package org.elara.app.validation.validation.validator;
+
+import jakarta.validation.Payload;
+import org.elara.app.validation.validation.annotation.HexColor;
+
+import java.lang.annotation.Annotation;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class HexColorValidatorTest {
+
+    private HexColor createAnnotation() {
+        return new HexColor() {
+
+            @Override
+            public Class<? extends Annotation> annotationType() {
+                return null;
+            }
+
+            @Override
+            public String message() {
+                return "";
+            }
+
+            @Override
+            public Class<?>[] groups() {
+                return new Class[0];
+            }
+
+            @Override
+            public Class<? extends Payload>[] payload() {
+                return new Class[0];
+            }
+        };
+    }
+
+}


### PR DESCRIPTION
Introduce a new `HexColor` annotation and its corresponding validator to validate hex color formats. Include unit tests to ensure the validator functions correctly.